### PR TITLE
ramips: kmod-sdhci-mt7620: switch dependence to kmod-mmc

### DIFF
--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -242,7 +242,7 @@ define Device/hc5661
   DTS := HC5661
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := HiWiFi HC5661
-  DEVICE_PACKAGES := kmod-usb2 kmod-sdhci kmod-sdhci-mt7620 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-usb2 kmod-sdhci-mt7620 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += hc5661
 
@@ -250,7 +250,7 @@ define Device/hc5761
   DTS := HC5761
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := HiWiFi HC5761 
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-sdhci kmod-sdhci-mt7620 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += hc5761
 
@@ -258,7 +258,7 @@ define Device/hc5861
   DTS := HC5861
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := HiWiFi HC5861
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-sdhci kmod-sdhci-mt7620 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += hc5861
 

--- a/target/linux/ramips/image/mt7628.mk
+++ b/target/linux/ramips/image/mt7628.mk
@@ -31,7 +31,7 @@ define Device/vocore2
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := VoCore VoCore2
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport \
-    kmod-sdhci kmod-sdhci-mt7620
+    kmod-sdhci-mt7620
 endef
 TARGET_DEVICES += vocore2
 

--- a/target/linux/ramips/modules.mk
+++ b/target/linux/ramips/modules.mk
@@ -29,7 +29,7 @@ $(eval $(call KernelPackage,pwm-mediatek))
 define KernelPackage/sdhci-mt7620
   SUBMENU:=Other modules
   TITLE:=MT7620 SDCI
-  DEPENDS:=@(TARGET_ramips_mt7620||TARGET_ramips_mt7628||TARGET_ramips_mt7621||TARGET_ramips_mt7688) +kmod-sdhci
+  DEPENDS:=@(TARGET_ramips_mt7620||TARGET_ramips_mt7628||TARGET_ramips_mt7621||TARGET_ramips_mt7688) +kmod-mmc
   KCONFIG:= \
 	CONFIG_MTK_MMC \
 	CONFIG_MTK_AEE_KDUMP=n \


### PR DESCRIPTION
mtk-mmc/mtk_sd.ko only depends on mmc_core and mmc_block.
And, we remove kmod-sdhci dependence assignment from all related target devices.

Signed-off-by: Furong Xu <xfr@outlook.com>